### PR TITLE
Replace keccak-256sum with pure php implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,38 +46,6 @@ extension=secp256k1.so
 ```
 
 
-
-### keccak-256sum
-
-You need [keccak-256sum command line](https://github.com/maandree/sha3sum).
-Which itself needs [libkeccak](https://github.com/maandree/libkeccak) to be installed on your system.
-
-Last tests were run using the following versions :
-* sha3sum-1.1.4
-* libkeccak-1.1.4
-
-On **macOS** you may find clues [here](https://github.com/maandree/libkeccak/issues/7).
-
-First install libkeccak
-```bash
-$> curl -L0k https://github.com/maandree/libkeccak/archive/1.1.4.zip > libkeccak-1.1.4.zip
-$> unzip libkeccak-1.1.4.zip
-$> cd libkeccak-1.1.4
-$> make
-$> sudo make install PREFIX=/usr
-$>
-```
-
-Then sha3sum
-```bash
-$> curl -L0k https://github.com/maandree/sha3sum/archive/1.1.4.zip > sha3sum-1.1.4.zip
-$> unzip sha3sum-1.1.4.zip
-$> cd sha3sum-1.1.4
-$> make
-$> sudo make install PREFIX=/usr
-$>
-```
-
 ## Examples
 
 You may run examples in `examples` folder.

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "require": {
         "php-64bit": ">=7.1",
         "bitwasp/secp256k1-php": "^0.1.2",
-        "bitwasp/buffertools": "^0.5.0"
+        "bitwasp/buffertools": "^0.5.0",
+        "kornrunner/keccak": "^1.0"
     },
     "license": "MIT",
     "authors": [

--- a/src/EthereumRawTx/Encoder/Keccak.php
+++ b/src/EthereumRawTx/Encoder/Keccak.php
@@ -2,6 +2,7 @@
 namespace EthereumRawTx\Encoder;
 
 use BitWasp\Buffertools\Buffer;
+use kornrunner\Keccak as Sha3;
 
 class Keccak
 {
@@ -14,14 +15,7 @@ class Keccak
     static function hash(Buffer $a, int $bits = 256): Buffer
     {
         /** @var string $sha */
-        $sha = exec(sprintf(
-            'echo "%s"  | keccak-%dsum -x -l',
-            $a->getHex(),
-            $bits
-        ));
-
-        // clean up command result
-        $sha = substr($sha, 0, 64);
+        $sha = Sha3::hash(hex2bin($a->getHex()), $bits);
 
         return Buffer::hex($sha);
     }


### PR DESCRIPTION
This removes external dependancy for `kecak-*sum` and `sha3sum` (also removed from README), and replaces code with pure php impl.

Tests are passing.