### PR TITLE
composer: require secp256k1 as extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,9 @@
     "type": "library",
     "require": {
         "php-64bit": ">=7.1",
-        "bitwasp/secp256k1-php": "^0.1.2",
         "bitwasp/buffertools": "^0.5.0",
-        "kornrunner/keccak": "^1.0"
+        "kornrunner/keccak": "^1.0",
+        "ext-secp256k1": "^0.1.0"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
`secp256k1` should be required as extension, not as php library

I've wanted to put the same version as it was originally, but I couldn't as the source isn't following versions of releases.

https://github.com/Bit-Wasp/secp256k1-php/blob/master/secp256k1/php_secp256k1.h#L12