### PR TITLE
Transaction: sign: v value depends on chainId

### DIFF
--- a/src/EthereumRawTx/Transaction.php
+++ b/src/EthereumRawTx/Transaction.php
@@ -203,7 +203,7 @@ class Transaction
 
         $this->r = Buffer::hex(Hex::trim(substr($sign->getHex(), 0, 64)));
         $this->s = Buffer::hex(Hex::trim(substr($sign->getHex(), 64)));
-        $this->v = Buffer::int($recId + 27 + $chainId->getInt() * 2 + 8);
+        $this->v = Buffer::int($recId + 27 + ($chainId->getInt() ? $chainId->getInt() * 2 + 8 : 0));
     }
 
     /**


### PR DESCRIPTION
Based on:
https://github.com/ethereumjs/ethereumjs-tx/blob/master/index.js#L234

https://ethereum.stackexchange.com/questions/37533/what-is-a-chainid-in-ethereum-how-is-it-different-than-networkid-and-how-is-it?rq=1

`chainId` stuff should be only calculated in if it's greater than 0.

Tests are passing.
